### PR TITLE
Add MIDI guitar support

### DIFF
--- a/2-gtl-performer
+++ b/2-gtl-performer
@@ -234,12 +234,15 @@
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_A], 127
 
-  // Call @DisableSendMicrophoneToGtl
-  midiToSend = AUM_TOGGLE_SEND_MICROPHONE_TO_GTL
-  Call @SendMidiNoteOffToAum
+  Call @DisableSendMicrophoneToGtl
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_MICROPHONE, FEEDBACK_DEACTIVATED]
   SendSysex sysexData, 4
+@End
+
+@DisableSendMicrophoneToGtl
+  midiToSend = AUM_TOGGLE_SEND_MICROPHONE_TO_GTL
+  Call @SendMidiNoteOffToAum
 @End
 
 @EnableSendingMicrophoneToGtl
@@ -247,12 +250,15 @@
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_A], 127
 
-  // Call @EnableSendMicrophoneToGtl
-  midiToSend = AUM_TOGGLE_SEND_MICROPHONE_TO_GTL
-  Call @SendMidiNoteOnToAum
+  Call @EnableSendMicrophoneToGtl
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_MICROPHONE, FEEDBACK_ACTIVATED]
   SendSysex sysexData, 4
+@End
+
+@EnableSendMicrophoneToGtl
+  midiToSend = AUM_TOGGLE_SEND_MICROPHONE_TO_GTL
+  Call @SendMidiNoteOnToAum
 @End
 
 @DisableSendingKeyboardToGtl
@@ -260,12 +266,15 @@
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_C], 127
 
-  // Call @DisableSendKeyboardToGtl
-  midiToSend = AUM_TOGGLE_SEND_KEYBOARD_TO_GTL
-  Call @SendMidiNoteOffToAum
+  Call @DisableSendKeyboardToGtl
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_KEYBOARD, FEEDBACK_DEACTIVATED]
   SendSysex sysexData, 4
+@End
+
+@DisableSendKeyboardToGtl
+  midiToSend = AUM_TOGGLE_SEND_KEYBOARD_TO_GTL
+  Call @SendMidiNoteOffToAum
 @End
 
 @EnableSendingKeyboardToGtl
@@ -273,20 +282,27 @@
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_C], 127
 
-  // Call @EnableSendKeyboardToGtl
-  midiToSend = AUM_TOGGLE_SEND_KEYBOARD_TO_GTL
-  Call @SendMidiNoteOnToAum
-
-  // Call @EnableKeyboard
-  midiToSend = AUM_ENABLE_KEYBOARD
-  Call @SendMidiNoteOnToAum
-
-  // Call @DisableGuitar
-  midiToSend = AUM_ENABLE_GUITAR
-  Call @SendMidiNoteOffToAum
+  Call @EnableSendKeyboardToGtl
+  Call @EnableKeyboard
+  Call @DisableGuitar
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_KEYBOARD, FEEDBACK_ACTIVATED]
   SendSysex sysexData, 4
+@End
+
+@EnableSendKeyboardToGtl
+  midiToSend = AUM_TOGGLE_SEND_KEYBOARD_TO_GTL
+  Call @SendMidiNoteOnToAum
+@End
+
+@EnableKeyboard
+  midiToSend = AUM_ENABLE_KEYBOARD
+  Call @SendMidiNoteOnToAum
+@End
+
+@DisableGuitar
+  midiToSend = AUM_ENABLE_GUITAR
+  Call @SendMidiNoteOffToAum
 @End
 
 @DisableSendingGuitarToGtl
@@ -294,12 +310,15 @@
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_D], 127
 
-  // Call @DisableSendGuitarToGtl
-  midiToSend = AUM_TOGGLE_SEND_GUITAR_TO_GTL
-  Call @SendMidiNoteOffToAum
+  Call @DisableSendGuitarToGtl
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_GUITAR, FEEDBACK_DEACTIVATED]
   SendSysex sysexData, 4
+@End
+
+@DisableSendGuitarToGtl
+  midiToSend = AUM_TOGGLE_SEND_GUITAR_TO_GTL
+  Call @SendMidiNoteOffToAum
 @End
 
 @EnableSendingGuitarToGtl
@@ -307,20 +326,27 @@
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_D], 127
 
-  // Call @EnableSendGuitarToGtl
-  midiToSend = AUM_TOGGLE_SEND_GUITAR_TO_GTL
-  Call @SendMidiNoteOnToAum
-
-  // Call @EnableGuitar
-  midiToSend = AUM_ENABLE_GUITAR
-  Call @SendMidiNoteOnToAum
-
-  // Call @DisableKeyboard
-  midiToSend = AUM_ENABLE_KEYBOARD
-  Call @SendMidiNoteOffToAum
+  Call @EnableSendGuitarToGtl
+  Call @EnableGuitar
+  Call @DisableKeyboard
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_GUITAR, FEEDBACK_ACTIVATED]
   SendSysex sysexData, 4
+@End
+
+@EnableSendGuitarToGtl
+  midiToSend = AUM_TOGGLE_SEND_GUITAR_TO_GTL
+  Call @SendMidiNoteOnToAum
+@End
+
+@EnableGuitar
+  midiToSend = AUM_ENABLE_GUITAR
+  Call @SendMidiNoteOnToAum
+@End
+
+@DisableKeyboard
+  midiToSend = AUM_ENABLE_KEYBOARD
+  Call @SendMidiNoteOffToAum
 @End
 
 @SendMidiNoteOnOffToGtl

--- a/2-gtl-performer
+++ b/2-gtl-performer
@@ -234,6 +234,7 @@
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_A], 127
 
+  // Call @DisableSendMicrophoneToGtl
   midiToSend = AUM_TOGGLE_SEND_MICROPHONE_TO_GTL
   Call @SendMidiNoteOffToAum
 
@@ -246,6 +247,7 @@
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_A], 127
 
+  // Call @EnableSendMicrophoneToGtl
   midiToSend = AUM_TOGGLE_SEND_MICROPHONE_TO_GTL
   Call @SendMidiNoteOnToAum
 
@@ -258,6 +260,7 @@
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_C], 127
 
+  // Call @DisableSendKeyboardToGtl
   midiToSend = AUM_TOGGLE_SEND_KEYBOARD_TO_GTL
   Call @SendMidiNoteOffToAum
 
@@ -270,8 +273,17 @@
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_C], 127
 
+  // Call @EnableSendKeyboardToGtl
   midiToSend = AUM_TOGGLE_SEND_KEYBOARD_TO_GTL
   Call @SendMidiNoteOnToAum
+
+  // Call @EnableKeyboard
+  midiToSend = AUM_ENABLE_KEYBOARD
+  Call @SendMidiNoteOnToAum
+
+  // Call @DisableGuitar
+  midiToSend = AUM_ENABLE_GUITAR
+  Call @SendMidiNoteOffToAum
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_KEYBOARD, FEEDBACK_ACTIVATED]
   SendSysex sysexData, 4
@@ -282,6 +294,7 @@
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_D], 127
 
+  // Call @DisableSendGuitarToGtl
   midiToSend = AUM_TOGGLE_SEND_GUITAR_TO_GTL
   Call @SendMidiNoteOffToAum
 
@@ -294,8 +307,17 @@
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_D], 127
 
+  // Call @EnableSendGuitarToGtl
   midiToSend = AUM_TOGGLE_SEND_GUITAR_TO_GTL
   Call @SendMidiNoteOnToAum
+
+  // Call @EnableGuitar
+  midiToSend = AUM_ENABLE_GUITAR
+  Call @SendMidiNoteOnToAum
+
+  // Call @DisableKeyboard
+  midiToSend = AUM_ENABLE_KEYBOARD
+  Call @SendMidiNoteOffToAum
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_GUITAR, FEEDBACK_ACTIVATED]
   SendSysex sysexData, 4

--- a/2-gtl-performer
+++ b/2-gtl-performer
@@ -130,9 +130,9 @@
 
 @InitVariables
   if Undefined midiToSend
-    sendingMicrophoneToGtl = UNDEFINED
-    sendingKeyboardToGtl = UNDEFINED
-    sendingGuitarToGtl = UNDEFINED
+    sendingMicrophoneToGtl = NO
+    sendingKeyboardToGtl = NO
+    sendingGuitarToGtl = NO
   endif
 
   midiToSend = UNDEFINED
@@ -160,9 +160,9 @@
   Call @SetClockLengthToInitialValue
   Call @ResetLastActiveLoopsOfGroups
 
-  Call @ToggleSendingMicrophoneToGtl
-  Call @ToggleSendingKeyboardToGtl
-  Call @ToggleSendingGuitarToGtl
+  Call @ToggleSendMicrophoneToGtl
+  Call @ToggleSendKeyboardToGtl
+  Call @ToggleSendGuitarToGtl
 
   Call @UnmuteFeedback
 @End
@@ -238,18 +238,18 @@
   SendSysex sysexData, 2
 @End
 
-@UnsendMicrophoneToGtl
+@BypassSendMicrophoneToGtl
   Log {Not sending microphone to GTL}
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_A], 127
 
-  Call @DisableSendMicrophoneToGtl
+  Call @BypassSendMicrophoneToGtl
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_MICROPHONE, FEEDBACK_DEACTIVATED]
   SendSysex sysexData, 4
 @End
 
-@DisableSendMicrophoneToGtl
+@BypassSendMicrophoneToGtl
   midiToSend = AUM_SEND_MICROPHONE_TO_GTL
   Call @SendMidiNoteOffToAum
 @End
@@ -270,7 +270,7 @@
   Call @SendMidiNoteOnToAum
 @End
 
-@UnsendKeyboardToGtl
+@BypassSendKeyboardToGtl
   Log {Not sending keyboard to GTL}
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_C], 127
@@ -307,7 +307,7 @@
   Call @SendMidiNoteOffToAum
 @End
 
-@UnsendGuitarToGtl
+@BypassSendGuitarToGtl
   Log {Not sending guitar to GTL}
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_D], 127
@@ -374,11 +374,11 @@
   lastButtonId = sysexData[1]
 
   if sysexAction = SYSEX_TOGGLE_SEND_MICROPHONE_TO_GTL
-    Call @ToggleSendingMicrophoneToGtl
+    Call @ToggleSendMicrophoneToGtl
   elseif sysexAction = SYSEX_TOGGLE_SEND_KEYBOARD_TO_GTL
-    Call @ToggleSendingKeyboardToGtl
+    Call @ToggleSendKeyboardToGtl
   elseif sysexAction = SYSEX_TOGGLE_SEND_GUITAR_TO_GTL
-    Call @ToggleSendingGuitarToGtl
+    Call @ToggleSendGuitarToGtl
   elseif sysexAction = SYSEX_RECORD_NEXT_LOOP_IN_GROUP
     Call @RecordNextLoopInGroup
   elseif sysexAction = SYSEX_TOGGLE_AND_SELECT_GROUP
@@ -425,7 +425,7 @@
   Log {Preparing guitar preset stored on button }, nextGuitarPreset, {, press button }, BB_BUTTON_D, { to activate!}
 @End
 
-@ToggleSendingMicrophoneToGtl
+@ToggleSendMicrophoneToGtl
   if nextMicrophonePreset <> UNDEFINED
     Call @ActivateMicrophonePreset
 
@@ -434,7 +434,7 @@
       sendingMicrophoneToGtl = YES
     endif
   elseif sendingMicrophoneToGtl
-    Call @UnsendMicrophoneToGtl
+    Call @BypassSendMicrophoneToGtl
     sendingMicrophoneToGtl = NO
   else
     Call @SendMicrophoneToGtl
@@ -442,7 +442,7 @@
   endif
 @End
 
-@ToggleSendingKeyboardToGtl
+@ToggleSendKeyboardToGtl
   if nextKeyboardPreset <> UNDEFINED
     Call @ActivateKeyboardPreset
 
@@ -451,7 +451,7 @@
       sendingKeyboardToGtl = YES
     endif
   elseif sendingKeyboardToGtl
-    Call @UnsendKeyboardToGtl
+    Call @BypassSendKeyboardToGtl
     sendingKeyboardToGtl = NO
   else
     Call @SendKeyboardToGtl
@@ -459,7 +459,7 @@
   endif
 @End
 
-@ToggleSendingGuitarToGtl
+@ToggleSendGuitarToGtl
   if nextGuitarPreset <> UNDEFINED
     Call @ActivateGuitarPreset
 
@@ -468,7 +468,7 @@
       sendingGuitarToGtl = YES
     endif
   elseif sendingGuitarToGtl
-    Call @UnsendGuitarToGtl
+    Call @BypassSendGuitarToGtl
     sendingGuitarToGtl = NO
   else
     Call @SendGuitarToGtl

--- a/2-gtl-performer
+++ b/2-gtl-performer
@@ -608,5 +608,3 @@
   FEEDBACK_ARMED = 19
   FEEDBACK_KEYBOARD = 21
 @End
-
-// Test

--- a/2-gtl-performer
+++ b/2-gtl-performer
@@ -108,6 +108,9 @@
   AUM_SEND_KEYBOARD_TO_GTL = 11
   AUM_SEND_GUITAR_TO_GTL = 1
 
+  AUM_ENABLE_KEYBOARD = 12
+  AUM_ENABLE_GUITAR = 13
+
   // Microphone button: A
   // Don't do anything yet in AUM... could activate/deactivate echo, delay, vocoder...
   AUM_SELECT_MICROPHONE_PRESET[BB_BUTTON_B] = 5
@@ -126,6 +129,12 @@
 @End
 
 @InitVariables
+  if Undefined midiToSend
+    sendingMicrophoneToGtl = UNDEFINED
+    sendingKeyboardToGtl = UNDEFINED
+    sendingGuitarToGtl = UNDEFINED
+  endif
+
   midiToSend = UNDEFINED
   midiDelay  = 0
 
@@ -229,7 +238,7 @@
   SendSysex sysexData, 2
 @End
 
-@DisableSendingMicrophoneToGtl
+@UnsendMicrophoneToGtl
   Log {Not sending microphone to GTL}
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_A], 127
@@ -245,7 +254,7 @@
   Call @SendMidiNoteOffToAum
 @End
 
-@EnableSendingMicrophoneToGtl
+@SendMicrophoneToGtl
   Log {Sending microphone to GTL}
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_A], 127
@@ -261,38 +270,31 @@
   Call @SendMidiNoteOnToAum
 @End
 
-@DisableSendingKeyboardToGtl
+@UnsendKeyboardToGtl
   Log {Not sending keyboard to GTL}
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_C], 127
 
-  Call @DisableSendKeyboardToGtl
+  midiToSend = AUM_SEND_KEYBOARD_TO_GTL
+  Call @SendMidiNoteOffToAum
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_KEYBOARD, FEEDBACK_DEACTIVATED]
   SendSysex sysexData, 4
 @End
 
-@DisableSendKeyboardToGtl
-  midiToSend = AUM_SEND_KEYBOARD_TO_GTL
-  Call @SendMidiNoteOffToAum
-@End
-
-@EnableSendingKeyboardToGtl
+@SendKeyboardToGtl
   Log {Sending keyboard to GTL}
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_C], 127
 
-  Call @EnableSendKeyboardToGtl
+  midiToSend = AUM_SEND_KEYBOARD_TO_GTL
+  Call @SendMidiNoteOnToAum
+
   Call @EnableKeyboard
   Call @DisableGuitar
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_KEYBOARD, FEEDBACK_ACTIVATED]
   SendSysex sysexData, 4
-@End
-
-@EnableSendKeyboardToGtl
-  midiToSend = AUM_SEND_KEYBOARD_TO_GTL
-  Call @SendMidiNoteOnToAum
 @End
 
 @EnableKeyboard
@@ -305,38 +307,31 @@
   Call @SendMidiNoteOffToAum
 @End
 
-@DisableSendingGuitarToGtl
+@UnsendGuitarToGtl
   Log {Not sending guitar to GTL}
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_D], 127
 
-  Call @DisableSendGuitarToGtl
+  midiToSend = AUM_SEND_GUITAR_TO_GTL
+  Call @SendMidiNoteOffToAum
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_GUITAR, FEEDBACK_DEACTIVATED]
   SendSysex sysexData, 4
 @End
 
-@DisableSendGuitarToGtl
-  midiToSend = AUM_SEND_GUITAR_TO_GTL
-  Call @SendMidiNoteOffToAum
-@End
-
-@EnableSendingGuitarToGtl
+@SendGuitarToGtl
   Log {Sending guitar to GTL}
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_D], 127
 
-  Call @EnableSendGuitarToGtl
+  midiToSend = AUM_SEND_GUITAR_TO_GTL
+  Call @SendMidiNoteOnToAum
+
   Call @EnableGuitar
   Call @DisableKeyboard
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_GUITAR, FEEDBACK_ACTIVATED]
   SendSysex sysexData, 4
-@End
-
-@EnableSendGuitarToGtl
-  midiToSend = AUM_SEND_GUITAR_TO_GTL
-  Call @SendMidiNoteOnToAum
 @End
 
 @EnableGuitar
@@ -435,14 +430,14 @@
     Call @ActivateMicrophonePreset
 
     if sendingMicrophoneToGtl = NO
-      Call @EnableSendingMicrophoneToGtl
+      Call @SendMicrophoneToGtl
       sendingMicrophoneToGtl = YES
     endif
   elseif sendingMicrophoneToGtl
-    Call @DisableSendingMicrophoneToGtl
+    Call @UnsendMicrophoneToGtl
     sendingMicrophoneToGtl = NO
   else
-    Call @EnableSendingMicrophoneToGtl
+    Call @SendMicrophoneToGtl
     sendingMicrophoneToGtl = YES
   endif
 @End
@@ -452,14 +447,14 @@
     Call @ActivateKeyboardPreset
 
     if sendingKeyboardToGtl = NO
-      Call @EnableSendingKeyboardToGtl
+      Call @SendKeyboardToGtl
       sendingKeyboardToGtl = YES
     endif
   elseif sendingKeyboardToGtl
-    Call @DisableSendingKeyboardToGtl
+    Call @UnsendKeyboardToGtl
     sendingKeyboardToGtl = NO
   else
-    Call @EnableSendingKeyboardToGtl
+    Call @SendKeyboardToGtl
     sendingKeyboardToGtl = YES
   endif
 @End
@@ -469,14 +464,14 @@
     Call @ActivateGuitarPreset
 
     if sendingGuitarToGtl = NO
-      Call @EnableSendingGuitarToGtl
+      Call @SendGuitarToGtl
       sendingGuitarToGtl = YES
     endif
   elseif sendingGuitarToGtl
-    Call @DisableSendingGuitarToGtl
+    Call @UnsendGuitarToGtl
     sendingGuitarToGtl = NO
   else
-    Call @EnableSendingGuitarToGtl
+    Call @SendGuitarToGtl
     sendingGuitarToGtl = YES
   endif
 @End

--- a/2-gtl-performer
+++ b/2-gtl-performer
@@ -297,7 +297,7 @@
   sendingGuitarToGtl = YES
 
   if sendingKeyboardToGtl
-    @DisableSendKeyboardToGtl
+    Call @DisableSendKeyboardToGtl
   endif
 
   Call @DisableKeyboard

--- a/2-gtl-performer
+++ b/2-gtl-performer
@@ -264,21 +264,6 @@
   SendSysex sysexData, 4
 @End
 
-@DisableSendKeyboardToGtl
-  Log {Not sending keyboard to GTL}
-
-  SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_C], 127
-
-  midiToSend = AUM_SEND_KEYBOARD_TO_GTL
-  Call @SendMidiNoteOffToAum
-
-  Call @DisableKeyboard
-  sendingKeyboardToGtl = NO
-
-  sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_KEYBOARD, FEEDBACK_DEACTIVATED]
-  SendSysex sysexData, 4
-@End
-
 @EnableSendKeyboardToGtl
   Log {Sending keyboard to GTL}
 
@@ -288,29 +273,15 @@
   Call @SendMidiNoteOnToAum
 
   Call @EnableKeyboard
-
   sendingKeyboardToGtl = YES
 
   if sendingGuitarToGtl
     Call @DisableSendGuitarToGtl
   endif
 
-  sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_KEYBOARD, FEEDBACK_ACTIVATED]
-  SendSysex sysexData, 4
-@End
-
-@DisableSendGuitarToGtl
-  Log {Not sending guitar to GTL}
-
-  SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_D], 127
-
-  midiToSend = AUM_SEND_GUITAR_TO_GTL
-  Call @SendMidiNoteOffToAum
-
   Call @DisableGuitar
-  sendingGuitarToGtl = NO
 
-  sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_GUITAR, FEEDBACK_DEACTIVATED]
+  sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_KEYBOARD, FEEDBACK_ACTIVATED]
   SendSysex sysexData, 4
 @End
 
@@ -323,14 +294,41 @@
   Call @SendMidiNoteOnToAum
 
   Call @EnableGuitar
-
   sendingGuitarToGtl = YES
 
   if sendingKeyboardToGtl
     @DisableSendKeyboardToGtl
   endif
 
+  Call @DisableKeyboard
+
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_GUITAR, FEEDBACK_ACTIVATED]
+  SendSysex sysexData, 4
+@End
+
+@DisableSendKeyboardToGtl
+  Log {Not sending keyboard to GTL}
+
+  SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_C], 127
+
+  midiToSend = AUM_SEND_KEYBOARD_TO_GTL
+  Call @SendMidiNoteOffToAum
+  sendingKeyboardToGtl = NO
+
+  sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_KEYBOARD, FEEDBACK_DEACTIVATED]
+  SendSysex sysexData, 4
+@End
+
+@DisableSendGuitarToGtl
+  Log {Not sending guitar to GTL}
+
+  SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_D], 127
+
+  midiToSend = AUM_SEND_GUITAR_TO_GTL
+  Call @SendMidiNoteOffToAum
+  sendingGuitarToGtl = NO
+
+  sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_GUITAR, FEEDBACK_DEACTIVATED]
   SendSysex sysexData, 4
 @End
 

--- a/2-gtl-performer
+++ b/2-gtl-performer
@@ -229,7 +229,7 @@
   SendSysex sysexData, 2
 @End
 
-@ToggleSendingMicrophoneToGtlOff
+@DisableSendingMicrophoneToGtl
   Log {Not sending microphone to GTL}
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_A], 127
@@ -241,7 +241,7 @@
   SendSysex sysexData, 4
 @End
 
-@ToggleSendingMicrophoneToGtlOn
+@EnableSendingMicrophoneToGtl
   Log {Sending microphone to GTL}
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_A], 127
@@ -253,7 +253,7 @@
   SendSysex sysexData, 4
 @End
 
-@ToggleSendingKeyboardToGtlOff
+@DisableSendingKeyboardToGtl
   Log {Not sending keyboard to GTL}
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_C], 127
@@ -265,7 +265,7 @@
   SendSysex sysexData, 4
 @End
 
-@ToggleSendingKeyboardToGtlOn
+@EnableSendingKeyboardToGtl
   Log {Sending keyboard to GTL}
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_C], 127
@@ -277,7 +277,7 @@
   SendSysex sysexData, 4
 @End
 
-@ToggleSendingGuitarToGtlOff
+@DisableSendingGuitarToGtl
   Log {Not sending guitar to GTL}
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_D], 127
@@ -289,7 +289,7 @@
   SendSysex sysexData, 4
 @End
 
-@ToggleSendingGuitarToGtlOn
+@EnableSendingGuitarToGtl
   Log {Sending guitar to GTL}
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_D], 127
@@ -387,14 +387,14 @@
     Call @ActivateMicrophonePreset
 
     if sendingMicrophoneToGtl = NO
-      Call @ToggleSendingMicrophoneToGtlOn
+      Call @EnableSendingMicrophoneToGtl
       sendingMicrophoneToGtl = YES
     endif
   elseif sendingMicrophoneToGtl
-    Call @ToggleSendingMicrophoneToGtlOff
+    Call @DisableSendingMicrophoneToGtl
     sendingMicrophoneToGtl = NO
   else
-    Call @ToggleSendingMicrophoneToGtlOn
+    Call @EnableSendingMicrophoneToGtl
     sendingMicrophoneToGtl = YES
   endif
 @End
@@ -404,14 +404,14 @@
     Call @ActivateKeyboardPreset
 
     if sendingKeyboardToGtl = NO
-      Call @ToggleSendingKeyboardToGtlOn
+      Call @EnableSendingKeyboardToGtl
       sendingKeyboardToGtl = YES
     endif
   elseif sendingKeyboardToGtl
-    Call @ToggleSendingKeyboardToGtlOff
+    Call @DisableSendingKeyboardToGtl
     sendingKeyboardToGtl = NO
   else
-    Call @ToggleSendingKeyboardToGtlOn
+    Call @EnableSendingKeyboardToGtl
     sendingKeyboardToGtl = YES
   endif
 @End
@@ -421,14 +421,14 @@
     Call @ActivateGuitarPreset
 
     if sendingGuitarToGtl = NO
-      Call @ToggleSendingGuitarToGtlOn
+      Call @EnableSendingGuitarToGtl
       sendingGuitarToGtl = YES
     endif
   elseif sendingGuitarToGtl
-    Call @ToggleSendingGuitarToGtlOff
+    Call @DisableSendingGuitarToGtl
     sendingGuitarToGtl = NO
   else
-    Call @ToggleSendingGuitarToGtlOn
+    Call @EnableSendingGuitarToGtl
     sendingGuitarToGtl = YES
   endif
 @End

--- a/2-gtl-performer
+++ b/2-gtl-performer
@@ -272,6 +272,7 @@
   midiToSend = AUM_SEND_KEYBOARD_TO_GTL
   Call @SendMidiNoteOffToAum
 
+  Call @DisableKeyboard
   sendingKeyboardToGtl = NO
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_KEYBOARD, FEEDBACK_DEACTIVATED]
@@ -287,22 +288,15 @@
   Call @SendMidiNoteOnToAum
 
   Call @EnableKeyboard
-  Call @DisableGuitar
 
   sendingKeyboardToGtl = YES
 
+  if sendingGuitarToGtl
+    Call @DisableSendGuitarToGtl
+  endif
+
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_KEYBOARD, FEEDBACK_ACTIVATED]
   SendSysex sysexData, 4
-@End
-
-@EnableKeyboard
-  midiToSend = AUM_ENABLE_KEYBOARD
-  Call @SendMidiNoteOnToAum
-@End
-
-@DisableGuitar
-  midiToSend = AUM_ENABLE_GUITAR
-  Call @SendMidiNoteOffToAum
 @End
 
 @DisableSendGuitarToGtl
@@ -313,6 +307,7 @@
   midiToSend = AUM_SEND_GUITAR_TO_GTL
   Call @SendMidiNoteOffToAum
 
+  Call @DisableGuitar
   sendingGuitarToGtl = NO
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_GUITAR, FEEDBACK_DEACTIVATED]
@@ -328,12 +323,25 @@
   Call @SendMidiNoteOnToAum
 
   Call @EnableGuitar
-  Call @DisableKeyboard
 
   sendingGuitarToGtl = YES
 
+  if sendingKeyboardToGtl
+    @DisableSendKeyboardToGtl
+  endif
+
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_GUITAR, FEEDBACK_ACTIVATED]
   SendSysex sysexData, 4
+@End
+
+@EnableKeyboard
+  midiToSend = AUM_ENABLE_KEYBOARD
+  Call @SendMidiNoteOnToAum
+@End
+
+@DisableKeyboard
+  midiToSend = AUM_ENABLE_KEYBOARD
+  Call @SendMidiNoteOffToAum
 @End
 
 @EnableGuitar
@@ -341,8 +349,8 @@
   Call @SendMidiNoteOnToAum
 @End
 
-@DisableKeyboard
-  midiToSend = AUM_ENABLE_KEYBOARD
+@DisableGuitar
+  midiToSend = AUM_ENABLE_GUITAR
   Call @SendMidiNoteOffToAum
 @End
 

--- a/2-gtl-performer
+++ b/2-gtl-performer
@@ -243,15 +243,13 @@
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_A], 127
 
-  Call @BypassSendMicrophoneToGtl
+  midiToSend = AUM_SEND_MICROPHONE_TO_GTL
+  Call @SendMidiNoteOffToAum
+
+  sendingMicrophoneToGtl = NO
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_MICROPHONE, FEEDBACK_DEACTIVATED]
   SendSysex sysexData, 4
-@End
-
-@BypassSendMicrophoneToGtl
-  midiToSend = AUM_SEND_MICROPHONE_TO_GTL
-  Call @SendMidiNoteOffToAum
 @End
 
 @SendMicrophoneToGtl
@@ -259,15 +257,13 @@
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_A], 127
 
-  Call @EnableSendMicrophoneToGtl
+  midiToSend = AUM_SEND_MICROPHONE_TO_GTL
+  Call @SendMidiNoteOnToAum
+
+  sendingMicrophoneToGtl = YES
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_MICROPHONE, FEEDBACK_ACTIVATED]
   SendSysex sysexData, 4
-@End
-
-@EnableSendMicrophoneToGtl
-  midiToSend = AUM_SEND_MICROPHONE_TO_GTL
-  Call @SendMidiNoteOnToAum
 @End
 
 @BypassSendKeyboardToGtl
@@ -277,6 +273,8 @@
 
   midiToSend = AUM_SEND_KEYBOARD_TO_GTL
   Call @SendMidiNoteOffToAum
+
+  sendingKeyboardToGtl = NO
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_KEYBOARD, FEEDBACK_DEACTIVATED]
   SendSysex sysexData, 4
@@ -292,6 +290,8 @@
 
   Call @EnableKeyboard
   Call @DisableGuitar
+
+  sendingKeyboardToGtl = YES
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_KEYBOARD, FEEDBACK_ACTIVATED]
   SendSysex sysexData, 4
@@ -315,6 +315,8 @@
   midiToSend = AUM_SEND_GUITAR_TO_GTL
   Call @SendMidiNoteOffToAum
 
+  sendingGuitarToGtl = NO
+
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_GUITAR, FEEDBACK_DEACTIVATED]
   SendSysex sysexData, 4
 @End
@@ -329,6 +331,8 @@
 
   Call @EnableGuitar
   Call @DisableKeyboard
+
+  sendingGuitarToGtl = YES
 
   sysexData = [SYSEX_ANNOUNCE_FEEDBACK, FEEDBACK_SENDING, FEEDBACK_GUITAR, FEEDBACK_ACTIVATED]
   SendSysex sysexData, 4
@@ -431,14 +435,11 @@
 
     if sendingMicrophoneToGtl = NO
       Call @SendMicrophoneToGtl
-      sendingMicrophoneToGtl = YES
     endif
   elseif sendingMicrophoneToGtl
     Call @BypassSendMicrophoneToGtl
-    sendingMicrophoneToGtl = NO
   else
     Call @SendMicrophoneToGtl
-    sendingMicrophoneToGtl = YES
   endif
 @End
 
@@ -448,14 +449,11 @@
 
     if sendingKeyboardToGtl = NO
       Call @SendKeyboardToGtl
-      sendingKeyboardToGtl = YES
     endif
   elseif sendingKeyboardToGtl
     Call @BypassSendKeyboardToGtl
-    sendingKeyboardToGtl = NO
   else
     Call @SendKeyboardToGtl
-    sendingKeyboardToGtl = YES
   endif
 @End
 
@@ -465,14 +463,11 @@
 
     if sendingGuitarToGtl = NO
       Call @SendGuitarToGtl
-      sendingGuitarToGtl = YES
     endif
   elseif sendingGuitarToGtl
     Call @BypassSendGuitarToGtl
-    sendingGuitarToGtl = NO
   else
     Call @SendGuitarToGtl
-    sendingGuitarToGtl = YES
   endif
 @End
 

--- a/2-gtl-performer
+++ b/2-gtl-performer
@@ -129,18 +129,8 @@
 @End
 
 @InitVariables
-  if Undefined midiToSend
-    sendingMicrophoneToGtl = NO
-    sendingKeyboardToGtl = NO
-    sendingGuitarToGtl = NO
-  endif
-
   midiToSend = UNDEFINED
   midiDelay  = 0
-
-  nextMicrophonePreset = BB_BUTTON_D
-  nextKeyboardPreset = BB_BUTTON_A
-  nextGuitarPreset = BB_BUTTON_A
 @End
 
 @Reset
@@ -160,9 +150,17 @@
   Call @SetClockLengthToInitialValue
   Call @ResetLastActiveLoopsOfGroups
 
-  Call @ToggleSendMicrophoneToGtl
-  Call @ToggleSendKeyboardToGtl
-  Call @ToggleSendGuitarToGtl
+  nextMicrophonePreset = BB_BUTTON_D
+  Call @ActivateMicrophonePreset
+  Call @EnableSendMicrophoneToGtl
+
+  nextKeyboardPreset = BB_BUTTON_A
+  Call @ActivateKeyboardPreset
+  Call @DisableSendKeyboardToGtl
+
+  nextGuitarPreset = BB_BUTTON_A
+  Call @ActivateGuitarPreset
+  Call @EnableSendGuitarToGtl
 
   Call @UnmuteFeedback
 @End

--- a/2-gtl-performer
+++ b/2-gtl-performer
@@ -104,9 +104,9 @@
 @End
 
 @InitAumMidiCodes
-  AUM_TOGGLE_SEND_MICROPHONE_TO_GTL = 0
-  AUM_TOGGLE_SEND_KEYBOARD_TO_GTL = 11
-  AUM_TOGGLE_SEND_GUITAR_TO_GTL = 1
+  AUM_SEND_MICROPHONE_TO_GTL = 0
+  AUM_SEND_KEYBOARD_TO_GTL = 11
+  AUM_SEND_GUITAR_TO_GTL = 1
 
   // Microphone button: A
   // Don't do anything yet in AUM... could activate/deactivate echo, delay, vocoder...
@@ -241,7 +241,7 @@
 @End
 
 @DisableSendMicrophoneToGtl
-  midiToSend = AUM_TOGGLE_SEND_MICROPHONE_TO_GTL
+  midiToSend = AUM_SEND_MICROPHONE_TO_GTL
   Call @SendMidiNoteOffToAum
 @End
 
@@ -257,7 +257,7 @@
 @End
 
 @EnableSendMicrophoneToGtl
-  midiToSend = AUM_TOGGLE_SEND_MICROPHONE_TO_GTL
+  midiToSend = AUM_SEND_MICROPHONE_TO_GTL
   Call @SendMidiNoteOnToAum
 @End
 
@@ -273,7 +273,7 @@
 @End
 
 @DisableSendKeyboardToGtl
-  midiToSend = AUM_TOGGLE_SEND_KEYBOARD_TO_GTL
+  midiToSend = AUM_SEND_KEYBOARD_TO_GTL
   Call @SendMidiNoteOffToAum
 @End
 
@@ -291,7 +291,7 @@
 @End
 
 @EnableSendKeyboardToGtl
-  midiToSend = AUM_TOGGLE_SEND_KEYBOARD_TO_GTL
+  midiToSend = AUM_SEND_KEYBOARD_TO_GTL
   Call @SendMidiNoteOnToAum
 @End
 
@@ -317,7 +317,7 @@
 @End
 
 @DisableSendGuitarToGtl
-  midiToSend = AUM_TOGGLE_SEND_GUITAR_TO_GTL
+  midiToSend = AUM_SEND_GUITAR_TO_GTL
   Call @SendMidiNoteOffToAum
 @End
 
@@ -335,7 +335,7 @@
 @End
 
 @EnableSendGuitarToGtl
-  midiToSend = AUM_TOGGLE_SEND_GUITAR_TO_GTL
+  midiToSend = AUM_SEND_GUITAR_TO_GTL
   Call @SendMidiNoteOnToAum
 @End
 

--- a/2-gtl-performer
+++ b/2-gtl-performer
@@ -238,7 +238,7 @@
   SendSysex sysexData, 2
 @End
 
-@BypassSendMicrophoneToGtl
+@DisableSendMicrophoneToGtl
   Log {Not sending microphone to GTL}
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_A], 127
@@ -252,7 +252,7 @@
   SendSysex sysexData, 4
 @End
 
-@SendMicrophoneToGtl
+@EnableSendMicrophoneToGtl
   Log {Sending microphone to GTL}
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_A], 127
@@ -266,7 +266,7 @@
   SendSysex sysexData, 4
 @End
 
-@BypassSendKeyboardToGtl
+@DisableSendKeyboardToGtl
   Log {Not sending keyboard to GTL}
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_C], 127
@@ -280,7 +280,7 @@
   SendSysex sysexData, 4
 @End
 
-@SendKeyboardToGtl
+@EnableSendKeyboardToGtl
   Log {Sending keyboard to GTL}
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_C], 127
@@ -307,7 +307,7 @@
   Call @SendMidiNoteOffToAum
 @End
 
-@BypassSendGuitarToGtl
+@DisableSendGuitarToGtl
   Log {Not sending guitar to GTL}
 
   SendMidiNoteOff BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_D], 127
@@ -321,7 +321,7 @@
   SendSysex sysexData, 4
 @End
 
-@SendGuitarToGtl
+@EnableSendGuitarToGtl
   Log {Sending guitar to GTL}
 
   SendMidiNoteOn BB_MIDI_CHANNEL, BB_BUTTONS_MIDI[BB_BUTTON_D], 127
@@ -434,12 +434,12 @@
     Call @ActivateMicrophonePreset
 
     if sendingMicrophoneToGtl = NO
-      Call @SendMicrophoneToGtl
+      Call @EnableSendMicrophoneToGtl
     endif
   elseif sendingMicrophoneToGtl
-    Call @BypassSendMicrophoneToGtl
+    Call @DisableSendMicrophoneToGtl
   else
-    Call @SendMicrophoneToGtl
+    Call @EnableSendMicrophoneToGtl
   endif
 @End
 
@@ -448,12 +448,12 @@
     Call @ActivateKeyboardPreset
 
     if sendingKeyboardToGtl = NO
-      Call @SendKeyboardToGtl
+      Call @EnableSendKeyboardToGtl
     endif
   elseif sendingKeyboardToGtl
-    Call @BypassSendKeyboardToGtl
+    Call @DisableSendKeyboardToGtl
   else
-    Call @SendKeyboardToGtl
+    Call @EnableSendKeyboardToGtl
   endif
 @End
 
@@ -462,12 +462,12 @@
     Call @ActivateGuitarPreset
 
     if sendingGuitarToGtl = NO
-      Call @SendGuitarToGtl
+      Call @EnableSendGuitarToGtl
     endif
   elseif sendingGuitarToGtl
-    Call @BypassSendGuitarToGtl
+    Call @DisableSendGuitarToGtl
   else
-    Call @SendGuitarToGtl
+    Call @EnableSendGuitarToGtl
   endif
 @End
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ The goal of GTL-Performer is to enable a single person to become a 1-wo*man-band
 - Click the channel's name ("MIDI Guitar")
 - Click the "MIDI settings" button (switches icon at the top left of the menu)
 - Click "Send to Bus B: Bypass"
-- Assign MIDI note (not CC!) 12 to channel 3 (with "Invert" enabled and "Toggle" disabled)
+- Assign MIDI note (not CC!) 12 to channel 3
 - Click "MIDI Guitar: Bypass"
-- Assign MIDI note (not CC!) 13 to channel 3 (with "Invert" enabled and "Toggle" disabled)
+- Assign MIDI note (not CC!) 13 to channel 3
 
 #### Microphone
 
@@ -84,7 +84,7 @@ The goal of GTL-Performer is to enable a single person to become a 1-wo*man-band
 - Click the channel's name ("Microphone")
 - Click the "MIDI settings" button (switches icon at the top left of the menu)
 - Click "Send to Bus A: Bypass"
-- Assign MIDI note (not CC!) 0 to channel 3 (with "Invert" enabled and "Toggle" disabled)
+- Assign MIDI note (not CC!) 0 to channel 3 (with "Invert" enabled)
 
 #### Keyboard
 
@@ -100,7 +100,7 @@ The goal of GTL-Performer is to enable a single person to become a 1-wo*man-band
 - Click the channel's name ("Keyboard")
 - Click the "MIDI settings" button (switches icon at the top left of the menu)
 - Click "Send to Bus A: Bypass"
-- Assign MIDI note (not CC!) 11 to channel 3 (with "Invert" enabled and "Toggle" disabled)
+- Assign MIDI note (not CC!) 11 to channel 3 (with "Invert" enabled)
 
 To switch between Chameleon's presets, it needs some presets that can be toggled using MIDI. First of all, create some presets (you can also use the factory presets, but they usually have a lot of reverb by default):
 
@@ -133,7 +133,7 @@ Now each preset needs to listen to some MIDI signal so it can be toggled on/off:
 - Click the channel's name ("Guitar")
 - Click the "MIDI settings" button (switches icon at the top left of the menu)
 - Click "Send to Bus A: Bypass"
-- Assign MIDI note (not CC!) 1 to channel 3 (with "Invert" enabled and "Toggle" disabled)
+- Assign MIDI note (not CC!) 1 to channel 3 (with "Invert" enabled)
 
 To switch between Tonebridge's presets, it needs some presets that can be toggled using MIDI. First of all, create some presets:
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ The goal of GTL-Performer is to enable a single person to become a 1-wo*man-band
     - If you're using a more recent device that has USB-C (not Lightning), you need to adapt the following gear list accordingly
 - A microphone
     - I have a generic dynamic one that is similar to the [Shure SM57](https://www.shure.com/en-US/products/microphones/sm58)
-- A MIDI keyboard
+- A MIDI keyboard (optional)
     - I have a [Korg nanoKEY2](https://www.korg.com/us/products/computergear/nanokey2/)
-    - But I'm also playing around with a [Fishman Triple Play Connect](https://www.fishman.com/tripleplay/) which transforms my guitar into a MIDI controller
 - A guitar that can be plugged into an audio interface
     - I have an acoustic one (steel strings), but an electric one might be suited even better
 - An external audio interface which allows to connect both a guitar and a microphone
@@ -46,6 +45,8 @@ The goal of GTL-Performer is to enable a single person to become a 1-wo*man-band
     - Hosts the input channels and virtual instruments, routes them as needed to GTL, runs the Mozaic scripts, etc.
 - [Mozaic Plugin Workshop (Mozaic)](https://apps.apple.com/us/app/mozaic-plugin-workshop/id1457962653) (8$)
     - Runs the present collection of scripts that manage the interplay between all involved software (using MIDI signals)
+- [MIDI Guitar 2](https://apps.apple.com/us/app/midi-guitar/id523095780) (30$)
+    - Transforms my guitar into a MIDI controller (I'm also playing around with a [Fishman Triple Play Connect](https://www.fishman.com/tripleplay/), hoping to improve accuracy of audio-to-MIDI translation)
 - [Chameleon AUv3 Sampler Plugin (Chameleon)](https://apps.apple.com/us/app/chameleon-auv3-sampler-plugin/id1456474953) (6$)
     - Or a similar sampler plugin that lets you create your own patches (with a specific audio file per MIDI note)
 - [RoughRider3 (RR)](https://apps.apple.com/us/app/roughrider3/id1496058931?ls=1) (free)
@@ -61,17 +62,18 @@ The goal of GTL-Performer is to enable a single person to become a 1-wo*man-band
 
 ### Audio routing
 
-#### Main out
+#### MIDI Guitar
 
-- In AUM, create a new audio channel and call it "Main out"
-- As source ("+" button on the very top), select "Mix Bus" -> "Bus P"
-- As destination (speaker button on the very bottom), select "Hardware Output" -> "Speaker"
-
-#### Receive from GTL
-
-- In AUM, create a new audio channel and call it "Receive from GTL"
-- As source, select "Inter-App Audio" -> "Group the Loop (Main Output)"
-- As destination, select "Mix Bus" -> "Bus P"
+- In AUM, create a new audio channel and call it "MIDI Guitar"
+- As source, select "Hardware Input" -> "Audio interface channel Y" (where your guitar is plugged in)
+- As insert/effect, select "Audio Unit Extension" -> "MIDI Guitar"
+- For another insert/effect, drag the slots up to show a "+1" button, press it, then select "Bus Send" -> "Bus B"
+- Click the channel's name ("MIDI Guitar")
+- Click the "MIDI settings" button (switches icon at the top left of the menu)
+- Click "Send to Bus B: Bypass"
+- Assign MIDI note (not CC!) 12 to channel 3 (with "Invert" enabled and "Toggle" disabled)
+- Click "MIDI Guitar: Bypass"
+- Assign MIDI note (not CC!) 13 to channel 3 (with "Invert" enabled and "Toggle" disabled)
 
 #### Microphone
 
@@ -82,7 +84,7 @@ The goal of GTL-Performer is to enable a single person to become a 1-wo*man-band
 - Click the channel's name ("Microphone")
 - Click the "MIDI settings" button (switches icon at the top left of the menu)
 - Click "Send to Bus A: Bypass"
-- Assign MIDI note (not CC!) 0 to channel 3
+- Assign MIDI note (not CC!) 0 to channel 3 (with "Invert" enabled and "Toggle" disabled)
 
 #### Keyboard
 
@@ -90,14 +92,15 @@ The goal of GTL-Performer is to enable a single person to become a 1-wo*man-band
 - As source, select "Audio Unit Extension" -> "Chameleon"
 - Click the "Chameleon" button
 - Click the "MIDI Route" button (the "backwards S" in the window's menu bar)
-- Click "nanoKEY2 KEYBOARD"
+- Click "MIDI Guitar @A2:1"
+- Click "nanoKEY2 KEYBOARD" (optional)
 - Close the window by pressing the "X" button
 - As insert/effect, select "Bus Send" -> "Bus A"
 - As destination, select "Mix Bus" -> "Bus P"
 - Click the channel's name ("Keyboard")
 - Click the "MIDI settings" button (switches icon at the top left of the menu)
 - Click "Send to Bus A: Bypass"
-- Assign MIDI note (not CC!) 11 to channel 3
+- Assign MIDI note (not CC!) 11 to channel 3 (with "Invert" enabled and "Toggle" disabled)
 
 To switch between Chameleon's presets, it needs some presets that can be toggled using MIDI. First of all, create some presets (you can also use the factory presets, but they usually have a lot of reverb by default):
 
@@ -123,14 +126,14 @@ Now each preset needs to listen to some MIDI signal so it can be toggled on/off:
 #### Guitar
 
 - In AUM, create a new audio channel and call it "Guitar"
-- As source, select "Hardware Input" -> "Audio interface channel Y" (where your guitar is plugged in)
+- As source, select "Mix Bus" -> "Receive from Bus B"
 - As insert/effect, select "Audio Unit Extension" -> "Tonebridge"
 - For another insert/effect, drag the slots up to show a "+1" button, press it, then select "Bus Send" -> "Bus A"
 - As destination, select "Mix Bus" -> "Bus P"
 - Click the channel's name ("Guitar")
 - Click the "MIDI settings" button (switches icon at the top left of the menu)
 - Click "Send to Bus A: Bypass"
-- Assign MIDI note (not CC!) 1 to channel 1
+- Assign MIDI note (not CC!) 1 to channel 3 (with "Invert" enabled and "Toggle" disabled)
 
 To switch between Tonebridge's presets, it needs some presets that can be toggled using MIDI. First of all, create some presets:
 
@@ -152,20 +155,25 @@ Now each preset needs to listen to some MIDI signal so it can be toggled on/off:
 - For the second, assign MIDI note 3
 - For the third, assign MIDI note 4
 
-### Keyboard
-
-TODO
-
-// - Keyboard (Audio)
-//     - Input: Audio Unit Extension -> Chameleon
-//     - Insert: Bus Send -> Bus A
-//     - Output: Mix Bus -> Bus P
-
-### Send to GTL
+#### Send to GTL
 
 - In AUM, create a new audio channel and call it "Sed to GTL"
 - As source, select "Mix Bus" -> "Bus A"
 - As destination, select "IAA / Audiobus Output" -> "IAA / AB Output 1" (GTL will listen there)
+
+#### Receive from GTL
+
+- In AUM, create a new audio channel and call it "Receive from GTL"
+- As source, select "Inter-App Audio" -> "Group the Loop (Main Output)"
+- As destination, select "Mix Bus" -> "Bus P"
+
+#### Main out
+
+- In AUM, create a new audio channel and call it "Main out"
+- As source ("+" button on the very top), select "Mix Bus" -> "Bus P"
+- As destination (speaker button on the very bottom), select "Hardware Output" -> "Speaker"
+
+#### Feedbacker
 
 ### Save and close
 


### PR DESCRIPTION
Besides other things, it makes sure that only either guitar or keyboard is enabled, as guitar is also a MIDI keyboard using MIDI Guitar 2 app (or Fishman Triple Play Connect).

So whenever the guitar is activated, the keyboard is disabled, and vice versa.